### PR TITLE
Use util fromfilename

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/drone/drone-cache-lib/cache"
 	"github.com/drone/drone-cache-lib/storage"
+	"github.com/drone/drone-cache-lib/archive/util"
 )
 
 type Plugin struct {
@@ -30,7 +31,13 @@ const (
 func (p *Plugin) Exec() error {
 	var err error
 
-	c := cache.NewDefault(p.Storage)
+	at, err := util.FromFilename(p.Filename)
+
+	if err == nil {
+		log.Info("Archive type determined.")
+	}
+
+	c := cache.New(p.Storage, at)
 
 	path := p.Path + p.Filename
 	fallbackPath := p.FallbackPath + p.Filename

--- a/plugin.go
+++ b/plugin.go
@@ -33,8 +33,8 @@ func (p *Plugin) Exec() error {
 
 	at, err := util.FromFilename(p.Filename)
 
-	if err == nil {
-		log.Info("Archive type determined.")
+	if err != nil {
+		return err
 	}
 
 	c := cache.New(p.Storage, at)


### PR DESCRIPTION
Made the Exec function in plugin.go use the util.FromFilename function to determine which archive we want. If it's a .tar filename we create a tar cache and if it's .tgz or .tar.gz filename we create a compressed tar cache.